### PR TITLE
Feature: use embedded hal 1.0.0 alpha.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ examples = []
 default = [ "util" ]
 
 [dependencies]
-embedded-hal = { version = "1.0.0-alpha.7" }
+embedded-hal = { version = "1.0.0-alpha.8" }
 
 libc = "0.2.66"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ optional = true
 [dev-dependencies]
 ssd1306 = "0.7.0"
 embedded-graphics = "0.7.1"
-linux-embedded-hal = "0.3.0"
-embedded-hal-compat = "0.4.0"
+linux-embedded-hal = "0.4.0-alpha.3"
+embedded-hal-compat = "0.7.0"
 
 [[bin]]
 name = "cp2130-util"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,7 +166,7 @@ fn main() {
 
             let mut buff = data.clone();
             
-            spi.transfer_inplace(&mut buff).unwrap();
+            spi.transfer_in_place(&mut buff).unwrap();
 
             cp2130.set_gpio_mode_level(spi_opts.cs_pin, GpioMode::PushPull, GpioLevel::High).unwrap();
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -143,7 +143,7 @@ pub enum TransferCommand {
 /// Inner struct contains CP2130 IO functions
 /// This is used to split SPI and GPIO components
 #[derive(Debug)]
-pub struct Inner {
+pub(crate) struct Inner {
     _device: UsbDevice<UsbContext>,
     handle: DeviceHandle<UsbContext>,
     endpoints: Endpoints,
@@ -762,48 +762,3 @@ impl Inner{
     }
 }
 
-impl embedded_hal::spi::blocking::SpiBus<u8> for Inner {
-    fn transfer<'w>(&mut self, buff: &'w mut [u8], out: &'w [u8]) -> Result<(), Self::Error> {
-        let _n = self.spi_write_read(&out, buff)?;
-        Ok(())
-    }
-
-    fn transfer_in_place<'w>(&mut self, data: &'w mut [u8]) -> Result<(), Self::Error> {
-        let mut read_to: Vec<u8> = Vec::with_capacity(data.len());
-        let read_to = read_to.as_mut_slice();
-        self.spi_write_read(data, read_to)?;
-        data.copy_from_slice(read_to);
-        Ok(())
-    }
-}
-
-impl embedded_hal::spi::blocking::SpiBusWrite<u8> for Inner {
-    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        let _n = self.spi_write(words)?;
-        Ok(())
-    }
-}
-
-impl embedded_hal::spi::blocking::SpiBusRead<u8> for Inner {
-    fn read(&mut self, buff: &mut [u8]) -> Result<(), Self::Error> {
-        let out = vec![0u8; buff.len()];
-        let _n = self.spi_write_read(&out, buff)?;
-        Ok(())
-    }
-}
-
-impl embedded_hal::spi::blocking::SpiBusFlush for Inner {
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-}
-
-impl embedded_hal::spi::ErrorType for Inner {
-    type Error = Error;
-}
-
-impl embedded_hal::spi::Error for Inner {
-    fn kind(&self) -> embedded_hal::spi::ErrorKind {
-        embedded_hal::spi::ErrorKind::Other
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,16 @@ pub struct Spi {
     inner: Arc<Mutex<Inner>>,
 }
 
+impl embedded_hal::spi::blocking::SpiDevice for Spi {
+    type Bus = Inner;
+
+    fn transaction<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self::Bus) -> Result<R, <Self::Bus as embedded_hal::spi::ErrorType>::Error>,
+    ) -> Result<R, Self::Error> {
+        let mut bus = self.inner.lock().unwrap();
+        // We lock the inner mutex before every transaction, so we don't need an extra mutex here.
+        f(&mut bus)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,43 +189,6 @@ pub struct Spi {
     inner: Arc<Mutex<Inner>>,
 }
 
-
-impl embedded_hal::spi::blocking::SpiBus<u8> for Spi {
-
-    fn transfer<'w>(&mut self, buff: &'w mut [u8], out: &'w [u8]) -> Result<(), Self::Error> {
-        let _n = self.inner.lock().unwrap().spi_write_read(&out, buff)?;
-        Ok(())
-    }
-
-    fn transfer_in_place<'w>(&mut self, data: &'w mut [u8]) -> Result<(), Self::Error> {
-        let mut read_to: Vec<u8> = Vec::with_capacity(data.len());
-        let read_to = read_to.as_mut_slice();
-        self.inner.lock().unwrap().spi_write_read(data, read_to)?;
-        data.copy_from_slice(read_to);
-        Ok(())
-    }
-}
-
-impl embedded_hal::spi::blocking::SpiBusWrite<u8> for Spi {
-
-    fn write(&mut self, words: &[u8] ) -> Result<(), Self::Error> {
-        let _n = self.inner.lock().unwrap().spi_write(words)?;
-        Ok(())
-    }
-}
-
-impl embedded_hal::spi::blocking::SpiBusRead<u8> for Spi {
-
-    fn read(&mut self, buff: &mut [u8] ) -> Result<(), Self::Error> {
-        let out = vec![0u8; buff.len()];
-        let _n = self.inner.lock().unwrap().spi_write_read(&out, buff)?;
-        Ok(())
-    }
-}
-
-impl embedded_hal::spi::blocking::SpiBusFlush for Spi {
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Update the embedded-hal dependency to `1.0.0-alpha.8` version.

Currently pending on the following dev-dependencies:

- linux-embedded-hal: https://github.com/rust-embedded/linux-embedded-hal/pull/83
- embedded-hal-compat:
    - https://github.com/ryankurte/embedded-hal-compat/pull/10, which in turn requires
    - https://github.com/silvergasp/embedded-hal-compat/pull/1