### PR TITLE
Add chip select management to SPI interface

### DIFF
--- a/examples/ssd1306.rs
+++ b/examples/ssd1306.rs
@@ -3,15 +3,15 @@
 use driver_cp2130::prelude::*;
 
 use embedded_graphics::{
-    text::Text,
     mono_font::{ascii::FONT_6X10, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
+    text::Text,
 };
 use linux_embedded_hal::Delay;
 
+use embedded_hal_compat::ReverseCompat as _;
 use ssd1306::{prelude::*, Ssd1306};
-use embedded_hal_compat::{ReverseCompat as _};
 
 fn main() {
     // Find matching devices

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -160,28 +160,20 @@ fn main() {
         Command::SpiTransfer{data, spi_opts} => {
             info!("Transmit: {}", hex::encode(&data));
 
-            let mut spi = cp2130.spi(spi_opts.channel, SpiConfig::default()).unwrap();
-
-            cp2130.set_gpio_mode_level(spi_opts.cs_pin, GpioMode::PushPull, GpioLevel::Low).unwrap();
+            let mut spi = cp2130.spi(spi_opts.channel, SpiConfig::default(), Some(spi_opts.cs_pin)).unwrap();
 
             let mut buff = data.clone();
             
             spi.transfer_in_place(&mut buff).unwrap();
-
-            cp2130.set_gpio_mode_level(spi_opts.cs_pin, GpioMode::PushPull, GpioLevel::High).unwrap();
 
             info!("Received: {}", hex::encode(buff));
         },
         Command::SpiWrite{data, spi_opts} => {
             info!("Transmit: {}", hex::encode(&data));
 
-            let mut spi = cp2130.spi(spi_opts.channel, SpiConfig::default()).unwrap();
-
-            cp2130.set_gpio_mode_level(spi_opts.cs_pin, GpioMode::PushPull, GpioLevel::Low).unwrap();
+            let mut spi = cp2130.spi(spi_opts.channel, SpiConfig::default(), Some(spi_opts.cs_pin)).unwrap();
 
             spi.write(&data).unwrap();
-
-            cp2130.set_gpio_mode_level(spi_opts.cs_pin, GpioMode::PushPull, GpioLevel::High).unwrap();
         },
         Command::Test(opts) => {
             run_tests(&mut cp2130, &opts);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,9 +1,7 @@
+pub use embedded_hal::spi::Mode as SpiMode;
 
-pub use embedded_hal::spi::{Mode as SpiMode};
+pub use crate::{Cp2130, Device, Error as Cp2130Error, InputPin, OutputPin, Spi};
 
-pub use crate::{Cp2130, Device, Spi, InputPin, OutputPin, Error as Cp2130Error};
+pub use crate::device::{GpioLevel, GpioMode, SpiClock, SpiConfig, UsbOptions};
 
-pub use crate::device::{UsbOptions, GpioMode, GpioLevel, SpiConfig, SpiClock};
-
-pub use crate::manager::{Manager, Filter};
-
+pub use crate::manager::{Filter, Manager};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,11 +1,9 @@
-
 extern crate driver_cp2130;
 use driver_cp2130::prelude::*;
 
 #[test]
 #[ignore]
 fn integration() {
-
     // Find matching devices
     let (device, descriptor) = Manager::device(Filter::default(), 0).unwrap();
 
@@ -16,5 +14,3 @@ fn integration() {
 
     let _ = &mut cp2130;
 }
-
-


### PR DESCRIPTION
With the changes to embedded-hal we need to expose either a SpiDevice (including chip select) or an SpiBus (without)...
This implements the former to avoid stacking mutexes, though the latter can be achieved by passing `None` when creating the device.